### PR TITLE
Switched to javascript method of retrieving ReCaptcha images

### DIFF
--- a/reCAPTCHA/src/android/lib/recaptcha/ReCaptcha.java
+++ b/reCAPTCHA/src/android/lib/recaptcha/ReCaptcha.java
@@ -290,7 +290,7 @@ public class ReCaptcha extends ImageView {
                 }
             }
         } catch (JSONException e) {
-            e.printStackTrace();
+            throw new ReCaptchaException("Unable to parse challenge response");
         } finally {
             httpClient.getConnectionManager().shutdown();
         }

--- a/reCAPTCHA/src/android/lib/recaptcha/ReCaptcha.java
+++ b/reCAPTCHA/src/android/lib/recaptcha/ReCaptcha.java
@@ -271,7 +271,7 @@ public class ReCaptcha extends ImageView {
             if (imageToken == null) {
                 throw new ReCaptchaException("Image token not found");
             }
-
+            this.imageToken = imageToken;     
             final String imageUrl = String.format(ReCaptcha.IMAGE_URL, imageToken);
 
             final HttpResponse response = httpClient.execute(new HttpGet(imageUrl));

--- a/reCAPTCHA/src/android/lib/recaptcha/ReCaptcha.java
+++ b/reCAPTCHA/src/android/lib/recaptcha/ReCaptcha.java
@@ -1,22 +1,5 @@
 package android.lib.recaptcha;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.protocol.HTTP;
-
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -28,9 +11,29 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.widget.ImageView;
 
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.protocol.HTTP;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 /**
  * <code>ReCaptcha</code> extends {@link android.widget.ImageView} to let you embed a <a href="http://captcha.net/">CAPTCHA</a>
  * in your applications in order to protect them against spam and other types of automated abuse.
+ *
  * @see <a href="https://developers.google.com/recaptcha/">reCAPTCHA</a>
  */
 public class ReCaptcha extends ImageView {
@@ -41,6 +44,7 @@ public class ReCaptcha extends ImageView {
     public interface OnShowChallengeListener {
         /**
          * Called when an attempt to show a <a href="http://captcha.net/">CAPTCHA</a> is completed.
+         *
          * @param shown <code>true</code> if a <a href="http://captcha.net/">CAPTCHA</a> is shown;
          *              otherwise, <code>false</code>.
          */
@@ -55,6 +59,7 @@ public class ReCaptcha extends ImageView {
         /**
          * Called when an answer entered by the user to solve the <a href="http://captcha.net/">CAPTCHA</a>
          * displayed is verified.
+         *
          * @param success <code>true</code> if the <a href="http://captcha.net/">CAPTCHA</a> is solved successfully;
          *                otherwise, <code>false</code>.
          */
@@ -63,11 +68,14 @@ public class ReCaptcha extends ImageView {
 
     private static final String TAG = "ReCaptcha";
 
-    private static final String HTML_URL         = "http://www.google.com/recaptcha/api/noscript?k=%s";
-    private static final String IMAGE_URL        = "http://www.google.com/recaptcha/api/%s";
     private static final String VERIFICATION_URL = "http://www.google.com/recaptcha/api/verify";
 
-    private String token;
+    private static final String CHALLENGE_URL = "http://www.google.com/recaptcha/api/challenge?k=%s";
+    private static final String RECAPTCHA_OBJECT_TOKEN_URL = "http://www.google.com/recaptcha/api/reload?c=%s&k=%s&type=%s";
+    private static final String IMAGE_URL = "http://www.google.com/recaptcha/api/image?c=%s";
+
+    private String imageToken;
+    private HashMap<String, String> publicKeyChallengeMap = new HashMap<String, String>();
 
     public ReCaptcha(final Context context) {
         super(context);
@@ -86,6 +94,7 @@ public class ReCaptcha extends ImageView {
      * <p>Subclasses may override this method and return customized {@link org.apache.http.client.HttpClient},
      * such as an {@link android.net.http.AndroidHttpClient} with custom {@link org.apache.http.params.HttpParams}.</p>
      * <p>The default behavior returns a {@link org.apache.http.impl.client.DefaultHttpClient}</p>
+     *
      * @return a {@link org.apache.http.client.HttpClient} for downloading ReCaptcha images.
      */
     protected HttpClient createHttpClient() {
@@ -98,11 +107,12 @@ public class ReCaptcha extends ImageView {
      * for your application.</p>
      * <p>This method executes synchronously and should not be invoked from the UI thread.
      * For asynchronous invocation, you may use {@link android.os.AsyncTask} or call {@link #showChallengeAsync(String, android.lib.recaptcha.ReCaptcha.OnShowChallengeListener)} instead.</p>
+     *
      * @param publicKey The public key that is unique to your domain and sub-domains (unless it is a global key).
      * @return <code>true</code> if a <a href="http://captcha.net/">CAPTCHA</a> {@link android.graphics.Bitmap}
      * is successfully downloaded and shown; otherwise, <code>false</code>.
      * @throws android.lib.recaptcha.ReCaptchaException if the downloaded <a href="http://captcha.net/">CAPTCHA</a> content is malformed.
-     * @throws java.io.IOException in case of a protocol or network connection problem.
+     * @throws java.io.IOException                      in case of a protocol or network connection problem.
      * @see #showChallengeAsync(String, android.lib.recaptcha.ReCaptcha.OnShowChallengeListener)
      */
     public final boolean showChallenge(final String publicKey) throws ReCaptchaException, IOException {
@@ -112,9 +122,9 @@ public class ReCaptcha extends ImageView {
 
         this.setImageDrawable(null);
 
-        this.token = null;
+        this.imageToken = null;
 
-        final Bitmap bitmap = this.downloadHtmlAndImage(publicKey);
+        final Bitmap bitmap = this.downloadImage(publicKey);
 
         this.setImageBitmap(bitmap);
 
@@ -125,8 +135,9 @@ public class ReCaptcha extends ImageView {
      * Downloads and shows a <a href="http://captcha.net/">CAPTCHA</a> image asynchronously.
      * <p>This method executes asynchronously and can be invoked from the UI thread.
      * For synchronous invocation, use {@link #showChallenge(String)}.</p>
+     *
      * @param publicKey The public key that is unique to your domain and sub-domains (unless it is global key).
-     * @param listener The callback to call when an attempt to show a <a href="http://captcha.net/">CAPTCHA</a> is completed.
+     * @param listener  The callback to call when an attempt to show a <a href="http://captcha.net/">CAPTCHA</a> is completed.
      * @see #showChallenge(String)
      */
     public final void showChallengeAsync(final String publicKey, final OnShowChallengeListener listener) {
@@ -136,12 +147,12 @@ public class ReCaptcha extends ImageView {
 
         this.setImageDrawable(null);
 
-        this.token = null;
+        this.imageToken = null;
 
         final Handler handler = new Handler() {
             @Override
             public void handleMessage(final Message message) {
-                final Bitmap bitmap = (Bitmap)message.obj;
+                final Bitmap bitmap = (Bitmap) message.obj;
                 final Bitmap scaled = Bitmap.createScaledBitmap(bitmap, bitmap.getWidth() * 2, bitmap.getHeight() * 2, true);
 
                 bitmap.recycle();
@@ -158,7 +169,7 @@ public class ReCaptcha extends ImageView {
             @Override
             protected Bitmap doInBackground(final String... publicKeys) {
                 try {
-                    return ReCaptcha.this.downloadHtmlAndImage(publicKeys[0]);
+                    return ReCaptcha.this.downloadImage(publicKeys[0]);
                 } catch (final ReCaptchaException e) {
                     Log.e(ReCaptcha.TAG, "The downloaded CAPTCHA content is malformed", e);
                 } catch (final IOException e) {
@@ -180,8 +191,9 @@ public class ReCaptcha extends ImageView {
      * displaying <a href="https://developers.google.com/recaptcha/">reCAPTCHA</a>.
      * <p>This method executes synchronously and should not be invoked from the UI thread.
      * For asynchronous invocation, you may use {@link android.os.AsyncTask} or call {@link #verifyAnswerAsync(String, String, android.lib.recaptcha.ReCaptcha.OnVerifyAnswerListener)} instead.</p>
+     *
      * @param privateKey The private key that is unique to your domain and sub-domains (unless it is a global key).
-     * @param answer The string the user entered to solve the <a href="http://captcha.net/">CAPTCHA</a> displayed.
+     * @param answer     The string the user entered to solve the <a href="http://captcha.net/">CAPTCHA</a> displayed.
      * @return <code>true</code> if the <a href="https://developers.google.com/recaptcha/">reCAPTCHA</a> was successful;
      * otherwise <code>false</code>.
      * @throws java.io.IOException in case of a protocol or network connection problem.
@@ -202,9 +214,10 @@ public class ReCaptcha extends ImageView {
     /**
      * Checks asynchronously whether the answer entered by the user is correct after your application
      * is successfully displaying <a href="https://developers.google.com/recaptcha/">reCAPTCHA</a>.
+     *
      * @param privateKey The private key that is unique to your domain and sub-domains (unless it is a global key).
-     * @param answer The string the user entered to solve the <a href="http://captcha.net/">CAPTCHA</a> displayed.
-     * @param listener The callback to call when an answer entered by the user is verified.
+     * @param answer     The string the user entered to solve the <a href="http://captcha.net/">CAPTCHA</a> displayed.
+     * @param listener   The callback to call when an answer entered by the user is verified.
      * @see #verifyAnswer(String, String)
      */
     public final void verifyAnswerAsync(final String privateKey, final String answer, final OnVerifyAnswerListener listener) {
@@ -220,7 +233,7 @@ public class ReCaptcha extends ImageView {
             @Override
             public void handleMessage(final Message message) {
                 if (listener != null) {
-                    listener.onAnswerVerified(((Boolean)message.obj).booleanValue());
+                    listener.onAnswerVerified((Boolean) message.obj);
                 }
             }
         };
@@ -229,7 +242,7 @@ public class ReCaptcha extends ImageView {
             @Override
             protected Boolean doInBackground(final String... params) {
                 try {
-                    return Boolean.valueOf(ReCaptcha.this.submitAnswer(params[0], params[1]));
+                    return ReCaptcha.this.submitAnswer(params[0], params[1]);
                 } catch (final IOException e) {
                     Log.e(ReCaptcha.TAG, "A protocol or network connection problem has occurred", e);
                 }
@@ -244,22 +257,22 @@ public class ReCaptcha extends ImageView {
         }.execute(privateKey, answer);
     }
 
-    private Bitmap downloadHtmlAndImage(final String publicKey) throws ReCaptchaException, IOException {
+    private Bitmap downloadImage(final String publicKey) throws ReCaptchaException, IOException {
         final HttpClient httpClient = this.createHttpClient();
 
         try {
-            final String html  = httpClient.execute(new HttpGet(String.format(ReCaptcha.HTML_URL, publicKey)), new BasicResponseHandler());
-            final String token = StringUtils.substringBetween(html, "value=\"", "\"");
+            String challenge = getChallenge(publicKey);
 
-            if (token == null) {
-                throw new ReCaptchaException("\"recaptcha_challenge_field\" not found from the downloaded HTML document");
+            if (challenge == null) {
+                throw new ReCaptchaException("ReCaptcha challenge not found");
             }
 
-            final String imageUrl = String.format(ReCaptcha.IMAGE_URL, StringUtils.substringBetween(html, "src=\"", "\""));
-
-            if (imageUrl == null) {
-                throw new ReCaptchaException("CAPTCHA image URL not found from the downloaded HTML document");
+            String imageToken = getImageToken(challenge, publicKey);
+            if (imageToken == null) {
+                throw new ReCaptchaException("Image token not found");
             }
+
+            final String imageUrl = String.format(ReCaptcha.IMAGE_URL, imageToken);
 
             final HttpResponse response = httpClient.execute(new HttpGet(imageUrl));
 
@@ -270,27 +283,54 @@ public class ReCaptcha extends ImageView {
                     throw new ReCaptchaException("Invalid CAPTCHA image");
                 }
 
-                this.token = token;
-
                 return bitmap;
             } finally {
                 if (response.getEntity() != null) {
                     response.getEntity().consumeContent();
                 }
             }
+        } catch (JSONException e) {
+            e.printStackTrace();
         } finally {
             httpClient.getConnectionManager().shutdown();
         }
+        return null;
     }
 
+    private String getImageToken(String challenge, String publicKey) throws IOException {
+        HttpClient httpClient = this.createHttpClient();
+        String imageTokenUrl = String.format(ReCaptcha.RECAPTCHA_OBJECT_TOKEN_URL, challenge, publicKey, "image");
+        String imageTokenResponse = httpClient.execute(new HttpGet(imageTokenUrl), new BasicResponseHandler());
+        return substringBetween(imageTokenResponse, "('", "',");
+
+    }
+
+    private String getChallenge(String publicKey) throws IOException, JSONException {
+        if (!publicKeyChallengeMap.containsKey(publicKey)) {
+            HttpClient httpClient = this.createHttpClient();
+            String challenegeResponse = httpClient.execute(new HttpGet(String.format(ReCaptcha.CHALLENGE_URL, publicKey)), new BasicResponseHandler());
+            final String recaptchaStateString = substringBetween(
+                    challenegeResponse
+                    , "RecaptchaState = ", "}") + "}";
+
+            JSONObject recaptchaStateObject = new JSONObject(recaptchaStateString);
+            String challenge = recaptchaStateObject.getString("challenge");
+            publicKeyChallengeMap.put(publicKey, challenge);
+            return challenge;
+        } else {
+            return publicKeyChallengeMap.get(publicKey);
+        }
+    }
+
+
     private boolean submitAnswer(final String privateKey, final String answer) throws IOException {
-        final HttpClient          httpClient = this.createHttpClient();
-        final HttpPost            request    = new HttpPost(ReCaptcha.VERIFICATION_URL);
-        final List<NameValuePair> params     = new ArrayList<NameValuePair>();
+        final HttpClient httpClient = this.createHttpClient();
+        final HttpPost request = new HttpPost(ReCaptcha.VERIFICATION_URL);
+        final List<NameValuePair> params = new ArrayList<NameValuePair>();
 
         params.add(new BasicNameValuePair("privatekey", privateKey));
         params.add(new BasicNameValuePair("remoteip", "127.0.0.1"));
-        params.add(new BasicNameValuePair("challenge", this.token));
+        params.add(new BasicNameValuePair("challenge", this.imageToken));
         params.add(new BasicNameValuePair("response", answer));
 
         try {
@@ -304,5 +344,19 @@ public class ReCaptcha extends ImageView {
         }
 
         return false;
+    }
+
+    private static String substringBetween(String str, String open, String close) {
+        if (str == null || open == null || close == null) {
+            return null;
+        }
+        int start = str.indexOf(open);
+        if (start != -1) {
+            int end = str.indexOf(close, start + open.length());
+            if (end != -1) {
+                return str.substring(start + open.length(), end);
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fixed several issues that I encountered using this:
- the captchas were too difficult to solve, because it looked to the noscript api. I switched it to the api that the javascript implementation uses, which results in significantly easier captchas (at least, in my experience). This requires one additional HTTP call per public key.
- I kept having conflicts with the inclusion of the apache commons library, so seeing as how the only method used is substringBetween(), I copied that method into this class, and removed the dependency on StringUtils entirely.
- reformatted, renamed, and fixed style issues according to Android Studio's style guidelines
